### PR TITLE
Fix mix-up of cover ID and graph ID preventing cover deletion

### DIFF
--- a/src/main/i5/las2peer/services/ocd/ServiceClass.java
+++ b/src/main/i5/las2peer/services/ocd/ServiceClass.java
@@ -1024,7 +1024,7 @@ public class ServiceClass extends RESTService {
 				}
 
 				try {
-					entityHandler.deleteCover(username, coverId, graphId, threadHandler);
+					entityHandler.deleteCover(username, graphId, coverId, threadHandler);
 					return Response.ok(requestHandler.writeConfirmationXml()).build();
 				} catch (IllegalArgumentException e) {
 					return requestHandler.writeError(Error.PARAMETER_INVALID, e.getMessage());


### PR DESCRIPTION
In the deleteCover function of ServiceClass, the coverId and graphId parameters are mixed up when calling deleteCover of the EntityHandler. This prevents deletion for most covers. The fix puts the parameters in correct order.