### PR TITLE
Fix removeMultiEdges method

### DIFF
--- a/rest_ocd_services/src/main/java/i5/las2peer/services/ocd/graphs/GraphProcessor.java
+++ b/rest_ocd_services/src/main/java/i5/las2peer/services/ocd/graphs/GraphProcessor.java
@@ -111,6 +111,7 @@ public class GraphProcessor {
 	protected void removeMultiEdges(CustomGraph graph) {
 		Iterator<Edge> edgesIt = graph.edges().iterator();
 		Map<Pair<Integer, Integer>, Double> nodePairWeights = new HashMap<Pair<Integer, Integer>, Double>();
+		ArrayList<Edge> edgesToBeRemoved = new ArrayList<>();
 		while (edgesIt.hasNext()) {
 			Edge edge = edgesIt.next();
 			Pair<Integer, Integer> nodePair = new Pair<Integer, Integer>(edge.getSourceNode().getIndex(), edge.getTargetNode().getIndex());
@@ -120,10 +121,14 @@ public class GraphProcessor {
 			} else {
 				edgeWeight += graph.getEdgeWeight(edge);
 				nodePairWeights.put(nodePair, edgeWeight);
-				graph.removeEdge(edge);
+				edgesToBeRemoved.add(edge);
 			}
-
 		}
+
+		for (Edge edge : edgesToBeRemoved) {
+			graph.removeEdge(edge);
+		}
+		
 		edgesIt = graph.edges().iterator();
 		while (edgesIt.hasNext()) {
 			Edge edge = edgesIt.next();


### PR DESCRIPTION
The method deleted edges while iterating over them, that causes removed edges to still be iterated over but be null which can crash iteration. This is now fixed by deleting them afterwards.